### PR TITLE
1.0.1 fixbuttoniPhoneRatioLegibility

### DIFF
--- a/index_moises.html
+++ b/index_moises.html
@@ -65,46 +65,25 @@
       <section class="reserve_container" id="reserve">
         <div class="panelReserve" id="stays">
           <div class="selectionImages">
-            <div>
-              <img
-                src="images/cabin1.jpeg"
-                alt="Bottom Mountain"
-                width="100px"
-              />
-              <p>Bottom mountain</p>
-            </div>
-            <div>
-              <img
-                src="images/cabin3.jpg"
-                alt="Middle Mountain"
-                width="100px"
-              />
-              <p>Middle Mountain</p>
-            </div>
-            <div>
-              <img
-                src="images/thouse1.png"
-                alt="Smuggler's Rest"
-                width="100px"
-              />
-              <p>Smuggler's Rest</p>
-            </div>
-            <div>
-              <img
-                src="images/cabin2.jpg"
-                alt="King of the Mountain"
-                width="120px"
-                height="100px"
-              />
-              <p>King of the mountain</p>
-            </div>
+            <img src="images/cabin1.jpeg" alt="Bottom Mountain" width="300px" />
+            <p>Bottom mountain</p>
+            <img src="images/cabin3.jpg" alt="Middle Mountain" width="300px" />
+            <p>Middle Mountain</p>
+            <img src="images/thouse1.png" alt="Smuggler's Rest" width="300px" />
+            <p>Smuggler's Rest</p>
+            <img
+              src="images/cabin2.jpg"
+              alt="King of the Mountain"
+              width="300px"
+            />
+            <p>King of the mountain</p>
           </div>
         </div>
         <div class="markSelection">
           <div class="panelReserve" id="activities">
-            <img src="images/zipline.jpg" alt="Zip-line" width="100px" />
-            <img src="images/hiking.jpg" alt="Hiking" width="100px" />
-            <img src="images/climbing.jpg" alt="Climbing" width="100px" />
+            <img src="images/zipline.jpg" alt="Zip-line"/>
+            <img src="images/hiking.jpg" alt="Hiking"/>
+            <img src="images/climbing.jpg" alt="Climbing"/>
           </div>
           <select name="house" id="houseSelection">
             <option value="bottomMountain">Bottom Mountain</option>
@@ -140,11 +119,7 @@
           </div>
         </div>
       </section>
-      <input
-        id="confirmButton"
-        type="submit"
-        value="Confirm my choices and reserve!"
-      />
+      <input id="confirmButton" type="submit" value="Confirm and reserve!" />
       <h2>Contact Us</h2>
       <section id="contact">
         <div id="contactForm">
@@ -174,7 +149,7 @@
     </main>
     <footer>
       Powered by: <b>Moisés López Iglesias</b>
-          <a
+      <a
         href="https://www.github.com/moiseslopez1014/"
         target="_blank"
         value="Moises's GitHub"

--- a/style_moises.css
+++ b/style_moises.css
@@ -40,7 +40,6 @@ h1 {
   font-size: 36px;
   margin: auto;
   margin-top: 50px;
-  padding-right: 15px;
   text-align: center;
   color: wheat;
 }
@@ -56,21 +55,21 @@ h1 b {
   flex-grow: 4;
 }
 .header__logo {
-  width: 100px;
-  height: 100px;
+  width: 70px;
+  height: 70px;
   border-radius: 50%;
 }
-.logo {
-}
+
 .header__nav {
   display: flex;
   justify-content: space-between;
+  flex-direction: column;
 }
 .header__link {
   text-decoration: none;
-  padding-right: 25px;
-  padding-bottom: 10px;
-  padding-left: 10px;
+  padding-right: 1px;
+  padding-bottom: 1px;
+  padding-left: 1px;
   color: white;
   font-size: 22px;
 }
@@ -105,9 +104,24 @@ h1 b {
 /*RESERVE*/
 .reserve_container {
   margin: 16px 6px 24px 6px;
+  flex-wrap: wrap;
   display: flex;
   justify-content: space-evenly;
 }
+
+#activities {
+justify-content: center; 
+}
+
+#activities > img {
+  width: 200px;
+}
+
+#activities > img:hover {
+  width: 350px;
+}
+
+
 
 #stays {
   display: flex;
@@ -124,7 +138,7 @@ h1 b {
 
 #houseSelection,
 #weekSelection {
-  font-size: large;
+  font-size: 14px;
   border-radius: 100%;
   text-align: center;
   border-style: groove;
@@ -133,8 +147,8 @@ h1 b {
 }
 
 #confirmButton {
-  padding: 16px;
-  font-size: 32px;
+  padding: 8px;
+  font-size: 28px;
   font-weight: 700;
   color: transparent;
   letter-spacing: 1px;
@@ -171,8 +185,10 @@ h1 b {
 #contact {
   margin: 40px 0 40px 0;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   gap: 20px;
+  align-items: center;
   line-height: 1.7;
   font-family: "Gill Sans", "Gill Sans MT", Calibri, "Trebuchet MS", sans-serif;
 }


### PR DESCRIPTION
1.0.1 First fix for Escapa Website, Smartphone supported

Changelog

The website were adjusted for a 390px smartphones.
Reserve button smaller
cabin images bigger
activities images adjusted and hover added
contactForm and contact list now is in column.
<img width="390" height="845" alt="1 0 1-1" src="https://github.com/user-attachments/assets/45557e30-c929-4675-b738-7b07d891068e" />
<img width="391" height="843" alt="1 0 1-2" src="https://github.com/user-attachments/assets/a20bf8a1-0d06-49d4-a4dc-fef1c6ef91e8" />
<img width="390" height="843" alt="1 0 1-3" src="https://github.com/user-attachments/assets/b51eea8b-4bfc-40af-b961-d86a4a721e83" />
